### PR TITLE
Automagically run a script to update our sandbox asset dates daily

### DIFF
--- a/.github/workflows/update-assets-date.yaml
+++ b/.github/workflows/update-assets-date.yaml
@@ -1,0 +1,28 @@
+name: Update Transaction Dates for Assets Users
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day.
+  workflow_dispatch: # Allows you to manually run this workflow from the Actions tab
+
+jobs:
+  update-date:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Run the script to update the date
+        run: python assets/update_date.py
+
+      - name: Commit and push if there are changes
+        run: |
+          git config --global user.email "4397978+ToddKerpelman@users.noreply.github.com"
+          git config --global user.name "ToddBot"
+          git diff --quiet || (git commit -am "Auto-update dates" && git push)

--- a/.github/workflows/update-assets-date.yaml
+++ b/.github/workflows/update-assets-date.yaml
@@ -2,7 +2,7 @@ name: Update Transaction Dates for Assets Users
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs at 00:00 UTC every day.
+    - cron: '30 0 * * *' # Runs at 00:30 UTC every day.
   workflow_dispatch: # Allows you to manually run this workflow from the Actions tab
 
 jobs:

--- a/assets/assets_custom_user.json
+++ b/assets/assets_custom_user.json
@@ -1,41 +1,41 @@
 {
-   "override_accounts":[
-      {
-         "type":"depository",
-         "subtype":"checking",
-         "identity":{
-            "names":[
-               "John Smith"
-            ],
-            "addresses":[
-               {
-                  "data":{
-                     "city":"New York",
-                     "country":"US",
-                     "postal_code":"10003",
-                     "region":"NY",
-                     "street":"10003 Broadway Road"
-                  },
-                  "primary":true
-               }
-            ]
-         },
-         "transactions":[
-            {
-               "date_transacted":"2020-12-16",
-               "date_posted":"2020-12-17",
-               "amount":292.29,
-               "description":"DEBIT CRD AUTOPAY 98712 000000000098712 KIUYPKFWRSGT YOTLKJHAUXL C",
-               "currency":"USD"
+    "override_accounts": [
+        {
+            "type": "depository",
+            "subtype": "checking",
+            "identity": {
+                "names": [
+                    "John Smith"
+                ],
+                "addresses": [
+                    {
+                        "data": {
+                            "city": "New York",
+                            "country": "US",
+                            "postal_code": "10003",
+                            "region": "NY",
+                            "street": "10003 Broadway Road"
+                        },
+                        "primary": true
+                    }
+                ]
             },
-            {
-               "date_transacted":"2020-10-19",
-               "date_posted":"2020-10-20",
-               "amount":1523.52,
-               "description":"CREDIT CRD AUTOPAY 29812 000000000098123 SPKFGKABCRGK DUXZYAYOTAL X",
-               "currency":"USD"
-            }
-         ]
-      }
-   ]
+            "transactions": [
+                {
+                    "date_transacted": "2023-11-12",
+                    "date_posted": "2023-11-13",
+                    "amount": 292.29,
+                    "description": "DEBIT CRD AUTOPAY 98712 000000000098712 KIUYPKFWRSGT YOTLKJHAUXL C",
+                    "currency": "USD"
+                },
+                {
+                    "date_transacted": "2023-09-15",
+                    "date_posted": "2023-09-16",
+                    "amount": 1523.52,
+                    "description": "CREDIT CRD AUTOPAY 29812 000000000098123 SPKFGKABCRGK DUXZYAYOTAL X",
+                    "currency": "USD"
+                }
+            ]
+        }
+    ]
 }

--- a/assets/assets_custom_user2.json
+++ b/assets/assets_custom_user2.json
@@ -5,15 +5,15 @@
       "subtype": "savings",
       "transactions": [
         {
-               "date_transacted":"2020-12-16",
-               "date_posted":"2020-12-17",
+               "date_transacted":"2022-04-16",
+               "date_posted":"2022-04-17",
                "amount":896.65,
                "description":"DEBIT CRD AUTOPAY 98712 000000000028791 KIUYPWRSGTKF UXYOTLLKJHA C",
                "currency":"USD"
             },
             {
-               "date_transacted":"2020-10-19",
-               "date_posted":"2020-10-20",
+               "date_transacted":"2020-04-19",
+               "date_posted":"2020-04-20",
                "amount":1708.12,
                "description":"CREDIT CRD AUTOPAY 29812 000000000098123 CRGKFKKSPABG UXZYOTAYLDA D",
                "currency":"USD"
@@ -64,6 +64,7 @@
                }
             ]
          },
+         "starting_balance":4300,
          "transactions":[
             {
                "amount":24.83,

--- a/assets/assets_custom_user2.json
+++ b/assets/assets_custom_user2.json
@@ -1,682 +1,682 @@
 {
-   "override_accounts":[
-{
-      "type": "depository",
-      "subtype": "savings",
-      "transactions": [
+    "override_accounts": [
         {
-               "date_transacted":"2022-04-16",
-               "date_posted":"2022-04-17",
-               "amount":896.65,
-               "description":"DEBIT CRD AUTOPAY 98712 000000000028791 KIUYPWRSGTKF UXYOTLLKJHA C",
-               "currency":"USD"
+            "type": "depository",
+            "subtype": "savings",
+            "transactions": [
+                {
+                    "date_transacted": "2023-11-02",
+                    "date_posted": "2023-11-03",
+                    "amount": 896.65,
+                    "description": "DEBIT CRD AUTOPAY 98712 000000000028791 KIUYPWRSGTKF UXYOTLLKJHA C",
+                    "currency": "USD"
+                },
+                {
+                    "date_transacted": "2021-11-05",
+                    "date_posted": "2021-11-06",
+                    "amount": 1708.12,
+                    "description": "CREDIT CRD AUTOPAY 29812 000000000098123 CRGKFKKSPABG UXZYOTAYLDA D",
+                    "currency": "USD"
+                }
+            ],
+            "identity": {
+                "names": [
+                    "John Smith"
+                ],
+                "addresses": [
+                    {
+                        "primary": true,
+                        "data": {
+                            "country": "US",
+                            "city": "New York",
+                            "street": "10003 Broadway Road",
+                            "postal_code": "10003",
+                            "region": "NY"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "depository",
+            "subtype": "checking",
+            "identity": {
+                "names": [
+                    "John Smith"
+                ],
+                "addresses": [
+                    {
+                        "data": {
+                            "city": "New York",
+                            "country": "US",
+                            "postal_code": "10003",
+                            "region": "NY",
+                            "street": "10003 Broadway Road"
+                        },
+                        "primary": true
+                    }
+                ],
+                "emails": [
+                    {
+                        "primary": true,
+                        "type": "primary",
+                        "data": "accountholder0@example.com"
+                    }
+                ]
             },
-            {
-               "date_transacted":"2020-04-19",
-               "date_posted":"2020-04-20",
-               "amount":1708.12,
-               "description":"CREDIT CRD AUTOPAY 29812 000000000098123 CRGKFKKSPABG UXZYOTAYLDA D",
-               "currency":"USD"
-            }
-      ],
-      "identity": {
-        "names": [
-          "John Smith"
-        ],
-        "addresses": [
-          {
-            "primary": true,
-            "data": {
-              "country": "US",
-              "city": "New York",
-              "street": "10003 Broadway Road",
-              "postal_code": "10003",
-              "region": "NY"
-            }
-          }
-        ]
-      }
-   },
-      {
-         "type":"depository",
-         "subtype":"checking",
-         "identity":{
-            "names":[
-               "John Smith"
-            ],
-            "addresses":[
-               {
-                  "data":{
-                     "city":"New York",
-                     "country":"US",
-                     "postal_code":"10003",
-                     "region":"NY",
-                     "street":"10003 Broadway Road"
-                  },
-                  "primary":true
-               }
-            ],
-            "emails":[
-               {
-                  "primary":true,
-                  "type":"primary",
-                  "data":"accountholder0@example.com"
-               }
+            "starting_balance": 4300,
+            "transactions": [
+                {
+                    "amount": 24.83,
+                    "date_posted": "2023-10-15",
+                    "date_transacted": "2023-10-15",
+                    "currency": "USD",
+                    "description": "Amazon"
+                },
+                {
+                    "amount": 38.85,
+                    "date_posted": "2023-10-15",
+                    "date_transacted": "2023-10-15",
+                    "currency": "USD",
+                    "description": "Sams Club Sam's Club"
+                },
+                {
+                    "amount": 2.62,
+                    "date_posted": "2023-10-15",
+                    "date_transacted": "2023-10-15",
+                    "currency": "USD",
+                    "description": "SHELL SERVICE S"
+                },
+                {
+                    "amount": 9.88,
+                    "date_posted": "2023-10-15",
+                    "date_transacted": "2023-10-15",
+                    "currency": "USD",
+                    "description": "HLU*HULU 012345 HULU.COM/BILL CA USA"
+                },
+                {
+                    "amount": 20.71,
+                    "date_posted": "2023-10-16",
+                    "date_transacted": "2023-10-16",
+                    "currency": "USD",
+                    "description": "DOMINO'S 0123  PURCHASE 012-012-0123 FL"
+                },
+                {
+                    "amount": 7.5,
+                    "date_posted": "2023-10-16",
+                    "date_transacted": "2023-10-16",
+                    "currency": "USD",
+                    "description": "PAYPAL           INST XFER  STARBUCKS       WEB ID: PAYPALSI01"
+                },
+                {
+                    "amount": 9.53,
+                    "date_posted": "2023-10-16",
+                    "date_transacted": "2023-10-16",
+                    "currency": "USD",
+                    "description": "HLU*HULU 0123456789012-U HULU.COM/BILL CADebit Card Withdrawal"
+                },
+                {
+                    "amount": 4.06,
+                    "date_posted": "2023-10-17",
+                    "date_transacted": "2023-10-17",
+                    "currency": "USD",
+                    "description": "Jimmy John's"
+                },
+                {
+                    "amount": 9.23,
+                    "date_posted": "2023-10-17",
+                    "date_transacted": "2023-10-17",
+                    "currency": "USD",
+                    "description": "POS DEBIT                UBER   *                 012-012-0123  CA"
+                },
+                {
+                    "amount": 10.75,
+                    "date_posted": "2023-10-17",
+                    "date_transacted": "2023-10-17",
+                    "currency": "USD",
+                    "description": "Sally Beauty"
+                },
+                {
+                    "amount": 3.35,
+                    "date_posted": "2023-10-17",
+                    "date_transacted": "2023-10-17",
+                    "currency": "USD",
+                    "description": "Wawa"
+                },
+                {
+                    "amount": 28.28,
+                    "date_posted": "2023-10-18",
+                    "date_transacted": "2023-10-18",
+                    "currency": "USD",
+                    "description": "CHEGG  ORDER 012-012-0123 CA                 "
+                },
+                {
+                    "amount": 13.89,
+                    "date_posted": "2023-10-18",
+                    "date_transacted": "2023-10-18",
+                    "currency": "USD",
+                    "description": "DOORDASH"
+                },
+                {
+                    "amount": 52.49,
+                    "date_posted": "2023-10-18",
+                    "date_transacted": "2023-10-18",
+                    "currency": "USD",
+                    "description": "APL*ITUNES.COM BILL   012-012-0123"
+                },
+                {
+                    "amount": -5000,
+                    "date_posted": "2023-10-18",
+                    "date_transacted": "2023-10-18",
+                    "currency": "USD",
+                    "description": "MONTHLY PAYCHECK"
+                },
+                {
+                    "amount": 39.69,
+                    "date_posted": "2023-10-19",
+                    "date_transacted": "2023-10-19",
+                    "currency": "USD",
+                    "description": "Qt"
+                },
+                {
+                    "amount": 8.75,
+                    "date_posted": "2023-10-20",
+                    "date_transacted": "2023-10-20",
+                    "currency": "USD",
+                    "description": " Card purchase APL*ITUNES.COM/BILL 012-012-0123 CA 01-01-0123"
+                },
+                {
+                    "amount": 9.21,
+                    "date_posted": "2023-10-20",
+                    "date_transacted": "2023-10-20",
+                    "currency": "USD",
+                    "description": "Playstation Network"
+                },
+                {
+                    "amount": 2.09,
+                    "date_posted": "2023-10-23",
+                    "date_transacted": "2023-10-23",
+                    "currency": "USD",
+                    "description": "Frys Food"
+                },
+                {
+                    "amount": 330.96,
+                    "date_posted": "2023-10-23",
+                    "date_transacted": "2023-10-23",
+                    "currency": "USD",
+                    "description": "NNT ULTA #012      012"
+                },
+                {
+                    "amount": 4.98,
+                    "date_posted": "2023-10-24",
+                    "date_transacted": "2023-10-24",
+                    "currency": "USD",
+                    "description": "MCDONALD'S F01234 BRONX NY                   "
+                },
+                {
+                    "amount": 10.8,
+                    "date_posted": "2023-10-24",
+                    "date_transacted": "2023-10-24",
+                    "currency": "USD",
+                    "description": "DEBIT CARD PURCHASE XXXXX0123 FANDANGO FANDANGO.CO CA"
+                },
+                {
+                    "amount": 38.15,
+                    "date_posted": "2023-10-25",
+                    "date_transacted": "2023-10-25",
+                    "currency": "USD",
+                    "description": "PURCHASE AUTHORIZED ON  PAPA JOHN'S #0123 012-012-0123 TX S012345678901234 CARD 0123"
+                },
+                {
+                    "amount": 0.75,
+                    "date_posted": "2023-10-25",
+                    "date_transacted": "2023-10-25",
+                    "currency": "USD",
+                    "description": "DEBIT CARD PURCHASE XXXXX0123 DOORDASH*WENDYS DOORDASH.CO CA"
+                },
+                {
+                    "amount": 11.11,
+                    "date_posted": "2023-10-25",
+                    "date_transacted": "2023-10-25",
+                    "currency": "USD",
+                    "description": "AMZN MKTP US*MW AMZN.COM/BILL WA USA"
+                },
+                {
+                    "amount": 51.15,
+                    "date_posted": "2023-10-25",
+                    "date_transacted": "2023-10-25",
+                    "currency": "USD",
+                    "description": "Texas Roadhouse"
+                },
+                {
+                    "amount": 18.75,
+                    "date_posted": "2023-10-25",
+                    "date_transacted": "2023-10-25",
+                    "currency": "USD",
+                    "description": "Withdrawal Debit Card STARBUCKS 012-012-0123 WA Date /01 01234567890123456789012 Card 0123"
+                },
+                {
+                    "amount": 15.91,
+                    "date_posted": "2023-10-25",
+                    "date_transacted": "2023-10-25",
+                    "currency": "USD",
+                    "description": "UBER   EATSDebit Card Purchase"
+                },
+                {
+                    "amount": 5.01,
+                    "date_posted": "2023-10-25",
+                    "date_transacted": "2023-10-25",
+                    "currency": "USD",
+                    "description": "LYFT - RIDERS CARD#0123"
+                },
+                {
+                    "amount": 3.74,
+                    "date_posted": "2023-10-26",
+                    "date_transacted": "2023-10-26",
+                    "currency": "USD",
+                    "description": "Withdrawal Debit Card Apl*Itunes.Com/Bill 012-012-0123 Ca Date /01 *      0123456789     * 0123"
+                },
+                {
+                    "amount": 5.23,
+                    "date_posted": "2023-10-26",
+                    "date_transacted": "2023-10-26",
+                    "currency": "USD",
+                    "description": "POSTMATES TIP HTTPSPOSTMATE CA               "
+                },
+                {
+                    "amount": 14.03,
+                    "date_posted": "2023-10-26",
+                    "date_transacted": "2023-10-26",
+                    "currency": "USD",
+                    "description": "0123 Dominos Pizza 012-012-0123 CA           "
+                },
+                {
+                    "amount": 8.42,
+                    "date_posted": "2023-10-27",
+                    "date_transacted": "2023-10-27",
+                    "currency": "USD",
+                    "description": "SUNOCO 0123456789"
+                },
+                {
+                    "amount": 0.75,
+                    "date_posted": "2023-10-27",
+                    "date_transacted": "2023-10-27",
+                    "currency": "USD",
+                    "description": "USPS.COM MOVER'S GUID 012-012-0123 TN        "
+                },
+                {
+                    "amount": 10.72,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "APL*ITUNES 01234567890 01-01"
+                },
+                {
+                    "amount": 7.51,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "Arco"
+                },
+                {
+                    "amount": 20.71,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "POS Debit - Visa Check Card 0123 - DOMINO'S 0123 012-012-0123 CA"
+                },
+                {
+                    "amount": 17.99,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "DAVE.COM 0123456789 CA"
+                },
+                {
+                    "amount": 95.11,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "The Home Depot"
+                },
+                {
+                    "amount": 7.49,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "PAYPAL           INST XFER  MICROSOFT       WEB ID: PAYPALSI01"
+                },
+                {
+                    "amount": 0.74,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "HLU*HULU 0123456789012 HULU.COM/"
+                },
+                {
+                    "amount": 11.98,
+                    "date_posted": "2023-10-28",
+                    "date_transacted": "2023-10-28",
+                    "currency": "USD",
+                    "description": "KFC C012345"
+                },
+                {
+                    "amount": 7.3,
+                    "date_posted": "2023-10-29",
+                    "date_transacted": "2023-10-29",
+                    "currency": "USD",
+                    "description": "CINEMARK MOVIE CLUB 012-012-0123 TX          "
+                },
+                {
+                    "amount": 11.05,
+                    "date_posted": "2023-10-29",
+                    "date_transacted": "2023-10-29",
+                    "currency": "USD",
+                    "description": "PIN POS Wal-Mart S CARD#0123"
+                },
+                {
+                    "amount": 6.14,
+                    "date_posted": "2023-10-29",
+                    "date_transacted": "2023-10-29",
+                    "currency": "USD",
+                    "description": "Check Card: UBER TRIP HELP.UBER.COM CA /01%% Card 01 #0123"
+                },
+                {
+                    "amount": 2.22,
+                    "date_posted": "2023-10-29",
+                    "date_transacted": "2023-10-29",
+                    "currency": "USD",
+                    "description": "BURGER KING #0123  CARD#0123"
+                },
+                {
+                    "amount": 3.73,
+                    "date_posted": "2023-10-29",
+                    "date_transacted": "2023-10-29",
+                    "currency": "USD",
+                    "description": "DBT Purchase APL*ITUNES.COM/BIL012-012-0123 CA            0123"
+                },
+                {
+                    "amount": 221.38,
+                    "date_posted": "2023-10-29",
+                    "date_transacted": "2023-10-29",
+                    "currency": "USD",
+                    "description": "ATTWithdrawalPayment"
+                },
+                {
+                    "amount": 34.95,
+                    "date_posted": "2023-10-29",
+                    "date_transacted": "2023-10-29",
+                    "currency": "USD",
+                    "description": "POS PURCHASE AMZN MKTP US*MW* AMZN.COM/BILL WA 012345 012345678  01:01"
+                },
+                {
+                    "amount": 8.11,
+                    "date_posted": "2023-10-30",
+                    "date_transacted": "2023-10-30",
+                    "currency": "USD",
+                    "description": "MICROSOFT*XBOX GAME PA MSBILL.INFO WA        "
+                },
+                {
+                    "amount": 3.74,
+                    "date_posted": "2023-10-30",
+                    "date_transacted": "2023-10-30",
+                    "currency": "USD",
+                    "description": "Debit Card Purchase - APL*ITUNES.COM/BILL"
+                },
+                {
+                    "amount": 12.03,
+                    "date_posted": "2023-10-30",
+                    "date_transacted": "2023-10-30",
+                    "currency": "USD",
+                    "description": "APL*ITUNES.COM/BIL 01-01 012-012"
+                },
+                {
+                    "amount": 8.73,
+                    "date_posted": "2023-10-30",
+                    "date_transacted": "2023-10-30",
+                    "currency": "USD",
+                    "description": "CARD TRANSACTION : APL*ITUNES.COM/BILL, 012-012-0123, CA FROM CARD#: XXXXXXXXXXXX0123"
+                },
+                {
+                    "amount": 226.85,
+                    "date_posted": "2023-10-30",
+                    "date_transacted": "2023-10-30",
+                    "currency": "USD",
+                    "description": "Frys Food"
+                },
+                {
+                    "amount": 9.96,
+                    "date_posted": "2023-10-30",
+                    "date_transacted": "2023-10-30",
+                    "currency": "USD",
+                    "description": "DOMINO'S 0123 CARD#0123"
+                },
+                {
+                    "amount": 4.64,
+                    "date_posted": "2023-10-30",
+                    "date_transacted": "2023-10-30",
+                    "currency": "USD",
+                    "description": "MCDONALD S F0123 *"
+                },
+                {
+                    "amount": 4.8,
+                    "date_posted": "2023-10-31",
+                    "date_transacted": "2023-10-31",
+                    "currency": "USD",
+                    "description": "POS DEBIT - WAL-MART #0123"
+                },
+                {
+                    "amount": 139.98,
+                    "date_posted": "2023-10-31",
+                    "date_transacted": "2023-10-31",
+                    "currency": "USD",
+                    "description": "BLIZZARD ENTERTAINM 012-012-0123 CA          "
+                },
+                {
+                    "amount": 10.83,
+                    "date_posted": "2023-10-31",
+                    "date_transacted": "2023-10-31",
+                    "currency": "USD",
+                    "description": "POS Debit - Visa Check Card 0123 - AMZN MKTP US*MW012 AMZN.COM B"
+                },
+                {
+                    "amount": 25.56,
+                    "date_posted": "2023-10-31",
+                    "date_transacted": "2023-10-31",
+                    "currency": "USD",
+                    "description": "WAL-MART #0123"
+                },
+                {
+                    "amount": 10.8,
+                    "date_posted": "2023-11-01",
+                    "date_transacted": "2023-11-01",
+                    "currency": "USD",
+                    "description": "BURGER KING #0123 CARD#0123"
+                },
+                {
+                    "amount": 19.59,
+                    "date_posted": "2023-11-01",
+                    "date_transacted": "2023-11-01",
+                    "currency": "USD",
+                    "description": "DENNY'S #0123"
+                },
+                {
+                    "amount": 64.73,
+                    "date_posted": "2023-11-02",
+                    "date_transacted": "2023-11-02",
+                    "currency": "USD",
+                    "description": "PURCHASE AUTHORIZED ON  AMZN Mktp US*MW*R* Amzn.com/bill WA S012345678901234 CARD 0123"
+                },
+                {
+                    "amount": 229.37,
+                    "date_posted": "2023-11-02",
+                    "date_transacted": "2023-11-02",
+                    "currency": "USD",
+                    "description": "Food Lion"
+                },
+                {
+                    "amount": 2.99,
+                    "date_posted": "2023-11-03",
+                    "date_transacted": "2023-11-03",
+                    "currency": "USD",
+                    "description": "POS Debit - Visa Check Card 0123 - NINTENDO *AMERI 012-012-0123"
+                },
+                {
+                    "amount": 1.73,
+                    "date_posted": "2023-11-04",
+                    "date_transacted": "2023-11-04",
+                    "currency": "USD",
+                    "description": "APL*ITUNES.COM/B 012-012-0123 CAUS Tran Date/Time: /0123 01:01:01"
+                },
+                {
+                    "amount": 12.23,
+                    "date_posted": "2023-11-05",
+                    "date_transacted": "2023-11-05",
+                    "currency": "USD",
+                    "description": "POS Debit - Visa Check Card 0123 - DAVE.COM 012-0123456 CA"
+                },
+                {
+                    "amount": 29.72,
+                    "date_posted": "2023-11-05",
+                    "date_transacted": "2023-11-05",
+                    "currency": "USD",
+                    "description": "0123 DOMINOS PIZZA"
+                },
+                {
+                    "amount": 18.97,
+                    "date_posted": "2023-11-05",
+                    "date_transacted": "2023-11-05",
+                    "currency": "USD",
+                    "description": "Microsoft*Xbox Live Gol"
+                },
+                {
+                    "amount": 85.5,
+                    "date_posted": "2023-11-06",
+                    "date_transacted": "2023-11-06",
+                    "currency": "USD",
+                    "description": "APPLE PAY"
+                },
+                {
+                    "amount": 6.28,
+                    "date_posted": "2023-11-06",
+                    "date_transacted": "2023-11-06",
+                    "currency": "USD",
+                    "description": "7-Eleven (Fast Food)"
+                },
+                {
+                    "amount": 91.43,
+                    "date_posted": "2023-11-06",
+                    "date_transacted": "2023-11-06",
+                    "currency": "USD",
+                    "description": "LOWES #012345"
+                },
+                {
+                    "amount": 12.97,
+                    "date_posted": "2023-11-07",
+                    "date_transacted": "2023-11-07",
+                    "currency": "USD",
+                    "description": "MICROSOFT   *OFFICE 01 MSBILL.INFO WA        "
+                },
+                {
+                    "amount": 7.5,
+                    "date_posted": "2023-11-08",
+                    "date_transacted": "2023-11-08",
+                    "currency": "USD",
+                    "description": "Skillz * ESPORTS 012-0123456 MA              "
+                },
+                {
+                    "amount": 11.83,
+                    "date_posted": "2023-11-09",
+                    "date_transacted": "2023-11-09",
+                    "currency": "USD",
+                    "description": "7-ELEVEN                          M01234 ?"
+                },
+                {
+                    "amount": 7.19,
+                    "date_posted": "2023-11-11",
+                    "date_transacted": "2023-11-11",
+                    "currency": "USD",
+                    "description": "PURCHASE AUTHORIZED ON  DOORDASH*WENDYS DOORDASH.COM CA S012345678901234 CARD 0123"
+                },
+                {
+                    "amount": 2.37,
+                    "date_posted": "2023-11-11",
+                    "date_transacted": "2023-11-11",
+                    "currency": "USD",
+                    "description": "STARBUCKS STORE 01 CARD#0123"
+                },
+                {
+                    "amount": 1.91,
+                    "date_posted": "2023-11-12",
+                    "date_transacted": "2023-11-12",
+                    "currency": "USD",
+                    "description": "CMS Vending"
+                },
+                {
+                    "amount": 8.75,
+                    "date_posted": "2023-11-12",
+                    "date_transacted": "2023-11-12",
+                    "currency": "USD",
+                    "description": "MONEY ORDER"
+                },
+                {
+                    "amount": 13.13,
+                    "date_posted": "2023-11-12",
+                    "date_transacted": "2023-11-12",
+                    "currency": "USD",
+                    "description": "DEBIT CARD PURCHASE XXXXX0123 GROUPON INC GROUPON.COM IL"
+                },
+                {
+                    "amount": 7.29,
+                    "date_posted": "2023-11-12",
+                    "date_transacted": "2023-11-12",
+                    "currency": "USD",
+                    "description": "APL* ITUNES.COM One Apple Park Way 012-012-01"
+                },
+                {
+                    "amount": 0.75,
+                    "date_posted": "2023-11-13",
+                    "date_transacted": "2023-11-13",
+                    "currency": "USD",
+                    "description": "CONTACTS SUBSCRIPTIO HTTPSWWW.HUBB NY        "
+                }
             ]
-         },
-         "starting_balance":4300,
-         "transactions":[
-            {
-               "amount":24.83,
-               "date_posted":"2022-03-29",
-               "date_transacted":"2022-03-29",
-               "currency":"USD",
-               "description":"Amazon"
-            },
-            {
-               "amount":38.85,
-               "date_posted":"2022-03-29",
-               "date_transacted":"2022-03-29",
-               "currency":"USD",
-               "description":"Sams Club Sam's Club"
-            },
-            {
-               "amount":2.62,
-               "date_posted":"2022-03-29",
-               "date_transacted":"2022-03-29",
-               "currency":"USD",
-               "description":"SHELL SERVICE S"
-            },
-            {
-               "amount":9.88,
-               "date_posted":"2022-03-29",
-               "date_transacted":"2022-03-29",
-               "currency":"USD",
-               "description":"HLU*HULU 012345 HULU.COM/BILL CA USA"
-            },
-            {
-               "amount":20.71,
-               "date_posted":"2022-03-30",
-               "date_transacted":"2022-03-30",
-               "currency":"USD",
-               "description":"DOMINO'S 0123  PURCHASE 012-012-0123 FL"
-            },
-            {
-               "amount":7.5,
-               "date_posted":"2022-03-30",
-               "date_transacted":"2022-03-30",
-               "currency":"USD",
-               "description":"PAYPAL           INST XFER  STARBUCKS       WEB ID: PAYPALSI01"
-            },
-            {
-               "amount":9.53,
-               "date_posted":"2022-03-30",
-               "date_transacted":"2022-03-30",
-               "currency":"USD",
-               "description":"HLU*HULU 0123456789012-U HULU.COM/BILL CADebit Card Withdrawal"
-            },
-            {
-               "amount":4.06,
-               "date_posted":"2022-03-31",
-               "date_transacted":"2022-03-31",
-               "currency":"USD",
-               "description":"Jimmy John's"
-            },
-            {
-               "amount":9.23,
-               "date_posted":"2022-03-31",
-               "date_transacted":"2022-03-31",
-               "currency":"USD",
-               "description":"POS DEBIT                UBER   *                 012-012-0123  CA"
-            },
-            {
-               "amount":10.75,
-               "date_posted":"2022-03-31",
-               "date_transacted":"2022-03-31",
-               "currency":"USD",
-               "description":"Sally Beauty"
-            },
-            {
-               "amount":3.35,
-               "date_posted":"2022-03-31",
-               "date_transacted":"2022-03-31",
-               "currency":"USD",
-               "description":"Wawa"
-            },
-            {
-               "amount":28.28,
-               "date_posted":"2022-04-01",
-               "date_transacted":"2022-04-01",
-               "currency":"USD",
-               "description":"CHEGG  ORDER 012-012-0123 CA                 "
-            },
-            {
-               "amount":13.89,
-               "date_posted":"2022-04-01",
-               "date_transacted":"2022-04-01",
-               "currency":"USD",
-               "description":"DOORDASH"
-            },
-            {
-               "amount":52.49,
-               "date_posted":"2022-04-01",
-               "date_transacted":"2022-04-01",
-               "currency":"USD",
-               "description":"APL*ITUNES.COM BILL   012-012-0123"
-            },
-            {
-               "amount":-5000,
-               "date_posted":"2022-04-01",
-               "date_transacted":"2022-04-01",
-               "currency":"USD",
-               "description":"MONTHLY PAYCHECK"
-            },
-            {
-               "amount":39.69,
-               "date_posted":"2022-04-02",
-               "date_transacted":"2022-04-02",
-               "currency":"USD",
-               "description":"Qt"
-            },
-            {
-               "amount":8.75,
-               "date_posted":"2022-04-03",
-               "date_transacted":"2022-04-03",
-               "currency":"USD",
-               "description":" Card purchase APL*ITUNES.COM/BILL 012-012-0123 CA 01-01-0123"
-            },
-            {
-               "amount":9.21,
-               "date_posted":"2022-04-03",
-               "date_transacted":"2022-04-03",
-               "currency":"USD",
-               "description":"Playstation Network"
-            },
-            {
-               "amount":2.09,
-               "date_posted":"2022-04-06",
-               "date_transacted":"2022-04-06",
-               "currency":"USD",
-               "description":"Frys Food"
-            },
-            {
-               "amount":330.96,
-               "date_posted":"2022-04-06",
-               "date_transacted":"2022-04-06",
-               "currency":"USD",
-               "description":"NNT ULTA #012      012"
-            },
-            {
-               "amount":4.98,
-               "date_posted":"2022-04-07",
-               "date_transacted":"2022-04-07",
-               "currency":"USD",
-               "description":"MCDONALD'S F01234 BRONX NY                   "
-            },
-            {
-               "amount":10.8,
-               "date_posted":"2022-04-07",
-               "date_transacted":"2022-04-07",
-               "currency":"USD",
-               "description":"DEBIT CARD PURCHASE XXXXX0123 FANDANGO FANDANGO.CO CA"
-            },
-            {
-               "amount":38.15,
-               "date_posted":"2022-04-08",
-               "date_transacted":"2022-04-08",
-               "currency":"USD",
-               "description":"PURCHASE AUTHORIZED ON  PAPA JOHN'S #0123 012-012-0123 TX S012345678901234 CARD 0123"
-            },
-            {
-               "amount":0.75,
-               "date_posted":"2022-04-08",
-               "date_transacted":"2022-04-08",
-               "currency":"USD",
-               "description":"DEBIT CARD PURCHASE XXXXX0123 DOORDASH*WENDYS DOORDASH.CO CA"
-            },
-            {
-               "amount":11.11,
-               "date_posted":"2022-04-08",
-               "date_transacted":"2022-04-08",
-               "currency":"USD",
-               "description":"AMZN MKTP US*MW AMZN.COM/BILL WA USA"
-            },
-            {
-               "amount":51.15,
-               "date_posted":"2022-04-08",
-               "date_transacted":"2022-04-08",
-               "currency":"USD",
-               "description":"Texas Roadhouse"
-            },
-            {
-               "amount":18.75,
-               "date_posted":"2022-04-08",
-               "date_transacted":"2022-04-08",
-               "currency":"USD",
-               "description":"Withdrawal Debit Card STARBUCKS 012-012-0123 WA Date /01 01234567890123456789012 Card 0123"
-            },
-            {
-               "amount":15.91,
-               "date_posted":"2022-04-08",
-               "date_transacted":"2022-04-08",
-               "currency":"USD",
-               "description":"UBER   EATSDebit Card Purchase"
-            },
-            {
-               "amount":5.01,
-               "date_posted":"2022-04-08",
-               "date_transacted":"2022-04-08",
-               "currency":"USD",
-               "description":"LYFT - RIDERS CARD#0123"
-            },
-            {
-               "amount":3.74,
-               "date_posted":"2022-04-09",
-               "date_transacted":"2022-04-09",
-               "currency":"USD",
-               "description":"Withdrawal Debit Card Apl*Itunes.Com/Bill 012-012-0123 Ca Date /01 *      0123456789     * 0123"
-            },
-            {
-               "amount":5.23,
-               "date_posted":"2022-04-09",
-               "date_transacted":"2022-04-09",
-               "currency":"USD",
-               "description":"POSTMATES TIP HTTPSPOSTMATE CA               "
-            },
-            {
-               "amount":14.03,
-               "date_posted":"2022-04-09",
-               "date_transacted":"2022-04-09",
-               "currency":"USD",
-               "description":"0123 Dominos Pizza 012-012-0123 CA           "
-            },
-            {
-               "amount":8.42,
-               "date_posted":"2022-04-10",
-               "date_transacted":"2022-04-10",
-               "currency":"USD",
-               "description":"SUNOCO 0123456789"
-            },
-            {
-               "amount":0.75,
-               "date_posted":"2022-04-10",
-               "date_transacted":"2022-04-10",
-               "currency":"USD",
-               "description":"USPS.COM MOVER'S GUID 012-012-0123 TN        "
-            },
-            {
-               "amount":10.72,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"APL*ITUNES 01234567890 01-01"
-            },
-            {
-               "amount":7.51,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"Arco"
-            },
-            {
-               "amount":20.71,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"POS Debit - Visa Check Card 0123 - DOMINO'S 0123 012-012-0123 CA"
-            },
-            {
-               "amount":17.99,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"DAVE.COM 0123456789 CA"
-            },
-            {
-               "amount":95.11,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"The Home Depot"
-            },
-            {
-               "amount":7.49,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"PAYPAL           INST XFER  MICROSOFT       WEB ID: PAYPALSI01"
-            },
-            {
-               "amount":0.74,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"HLU*HULU 0123456789012 HULU.COM/"
-            },
-            {
-               "amount":11.98,
-               "date_posted":"2022-04-11",
-               "date_transacted":"2022-04-11",
-               "currency":"USD",
-               "description":"KFC C012345"
-            },
-            {
-               "amount":7.3,
-               "date_posted":"2022-04-12",
-               "date_transacted":"2022-04-12",
-               "currency":"USD",
-               "description":"CINEMARK MOVIE CLUB 012-012-0123 TX          "
-            },
-            {
-               "amount":11.05,
-               "date_posted":"2022-04-12",
-               "date_transacted":"2022-04-12",
-               "currency":"USD",
-               "description":"PIN POS Wal-Mart S CARD#0123"
-            },
-            {
-               "amount":6.14,
-               "date_posted":"2022-04-12",
-               "date_transacted":"2022-04-12",
-               "currency":"USD",
-               "description":"Check Card: UBER TRIP HELP.UBER.COM CA /01%% Card 01 #0123"
-            },
-            {
-               "amount":2.22,
-               "date_posted":"2022-04-12",
-               "date_transacted":"2022-04-12",
-               "currency":"USD",
-               "description":"BURGER KING #0123  CARD#0123"
-            },
-            {
-               "amount":3.73,
-               "date_posted":"2022-04-12",
-               "date_transacted":"2022-04-12",
-               "currency":"USD",
-               "description":"DBT Purchase APL*ITUNES.COM/BIL012-012-0123 CA            0123"
-            },
-            {
-               "amount":221.38,
-               "date_posted":"2022-04-12",
-               "date_transacted":"2022-04-12",
-               "currency":"USD",
-               "description":"ATTWithdrawalPayment"
-            },
-            {
-               "amount":34.95,
-               "date_posted":"2022-04-12",
-               "date_transacted":"2022-04-12",
-               "currency":"USD",
-               "description":"POS PURCHASE AMZN MKTP US*MW* AMZN.COM/BILL WA 012345 012345678  01:01"
-            },
-            {
-               "amount":8.11,
-               "date_posted":"2022-04-13",
-               "date_transacted":"2022-04-13",
-               "currency":"USD",
-               "description":"MICROSOFT*XBOX GAME PA MSBILL.INFO WA        "
-            },
-            {
-               "amount":3.74,
-               "date_posted":"2022-04-13",
-               "date_transacted":"2022-04-13",
-               "currency":"USD",
-               "description":"Debit Card Purchase - APL*ITUNES.COM/BILL"
-            },
-            {
-               "amount":12.03,
-               "date_posted":"2022-04-13",
-               "date_transacted":"2022-04-13",
-               "currency":"USD",
-               "description":"APL*ITUNES.COM/BIL 01-01 012-012"
-            },
-            {
-               "amount":8.73,
-               "date_posted":"2022-04-13",
-               "date_transacted":"2022-04-13",
-               "currency":"USD",
-               "description":"CARD TRANSACTION : APL*ITUNES.COM/BILL, 012-012-0123, CA FROM CARD#: XXXXXXXXXXXX0123"
-            },
-            {
-               "amount":226.85,
-               "date_posted":"2022-04-13",
-               "date_transacted":"2022-04-13",
-               "currency":"USD",
-               "description":"Frys Food"
-            },
-            {
-               "amount":9.96,
-               "date_posted":"2022-04-13",
-               "date_transacted":"2022-04-13",
-               "currency":"USD",
-               "description":"DOMINO'S 0123 CARD#0123"
-            },
-            {
-               "amount":4.64,
-               "date_posted":"2022-04-13",
-               "date_transacted":"2022-04-13",
-               "currency":"USD",
-               "description":"MCDONALD S F0123 *"
-            },
-            {
-               "amount":4.8,
-               "date_posted":"2022-04-14",
-               "date_transacted":"2022-04-14",
-               "currency":"USD",
-               "description":"POS DEBIT - WAL-MART #0123"
-            },
-            {
-               "amount":139.98,
-               "date_posted":"2022-04-14",
-               "date_transacted":"2022-04-14",
-               "currency":"USD",
-               "description":"BLIZZARD ENTERTAINM 012-012-0123 CA          "
-            },
-            {
-               "amount":10.83,
-               "date_posted":"2022-04-14",
-               "date_transacted":"2022-04-14",
-               "currency":"USD",
-               "description":"POS Debit - Visa Check Card 0123 - AMZN MKTP US*MW012 AMZN.COM B"
-            },
-            {
-               "amount":25.56,
-               "date_posted":"2022-04-14",
-               "date_transacted":"2022-04-14",
-               "currency":"USD",
-               "description":"WAL-MART #0123"
-            },
-            {
-               "amount":10.8,
-               "date_posted":"2022-04-15",
-               "date_transacted":"2022-04-15",
-               "currency":"USD",
-               "description":"BURGER KING #0123 CARD#0123"
-            },
-            {
-               "amount":19.59,
-               "date_posted":"2022-04-15",
-               "date_transacted":"2022-04-15",
-               "currency":"USD",
-               "description":"DENNY'S #0123"
-            },
-            {
-               "amount":64.73,
-               "date_posted":"2022-04-16",
-               "date_transacted":"2022-04-16",
-               "currency":"USD",
-               "description":"PURCHASE AUTHORIZED ON  AMZN Mktp US*MW*R* Amzn.com/bill WA S012345678901234 CARD 0123"
-            },
-            {
-               "amount":229.37,
-               "date_posted":"2022-04-16",
-               "date_transacted":"2022-04-16",
-               "currency":"USD",
-               "description":"Food Lion"
-            },
-            {
-               "amount":2.99,
-               "date_posted":"2022-04-17",
-               "date_transacted":"2022-04-17",
-               "currency":"USD",
-               "description":"POS Debit - Visa Check Card 0123 - NINTENDO *AMERI 012-012-0123"
-            },
-            {
-               "amount":1.73,
-               "date_posted":"2022-04-18",
-               "date_transacted":"2022-04-18",
-               "currency":"USD",
-               "description":"APL*ITUNES.COM/B 012-012-0123 CAUS Tran Date/Time: /0123 01:01:01"
-            },
-            {
-               "amount":12.23,
-               "date_posted":"2022-04-19",
-               "date_transacted":"2022-04-19",
-               "currency":"USD",
-               "description":"POS Debit - Visa Check Card 0123 - DAVE.COM 012-0123456 CA"
-            },
-            {
-               "amount":29.72,
-               "date_posted":"2022-04-19",
-               "date_transacted":"2022-04-19",
-               "currency":"USD",
-               "description":"0123 DOMINOS PIZZA"
-            },
-            {
-               "amount":18.97,
-               "date_posted":"2022-04-19",
-               "date_transacted":"2022-04-19",
-               "currency":"USD",
-               "description":"Microsoft*Xbox Live Gol"
-            },
-            {
-               "amount":85.5,
-               "date_posted":"2022-04-20",
-               "date_transacted":"2022-04-20",
-               "currency":"USD",
-               "description":"APPLE PAY"
-            },
-            {
-               "amount":6.28,
-               "date_posted":"2022-04-20",
-               "date_transacted":"2022-04-20",
-               "currency":"USD",
-               "description":"7-Eleven (Fast Food)"
-            },
-            {
-               "amount":91.43,
-               "date_posted":"2022-04-20",
-               "date_transacted":"2022-04-20",
-               "currency":"USD",
-               "description":"LOWES #012345"
-            },
-            {
-               "amount":12.97,
-               "date_posted":"2022-04-21",
-               "date_transacted":"2022-04-21",
-               "currency":"USD",
-               "description":"MICROSOFT   *OFFICE 01 MSBILL.INFO WA        "
-            },
-            {
-               "amount":7.5,
-               "date_posted":"2022-04-22",
-               "date_transacted":"2022-04-22",
-               "currency":"USD",
-               "description":"Skillz * ESPORTS 012-0123456 MA              "
-            },
-            {
-               "amount":11.83,
-               "date_posted":"2022-04-23",
-               "date_transacted":"2022-04-23",
-               "currency":"USD",
-               "description":"7-ELEVEN                          M01234 ?"
-            },
-            {
-               "amount":7.19,
-               "date_posted":"2022-04-25",
-               "date_transacted":"2022-04-25",
-               "currency":"USD",
-               "description":"PURCHASE AUTHORIZED ON  DOORDASH*WENDYS DOORDASH.COM CA S012345678901234 CARD 0123"
-            },
-            {
-               "amount":2.37,
-               "date_posted":"2022-04-25",
-               "date_transacted":"2022-04-25",
-               "currency":"USD",
-               "description":"STARBUCKS STORE 01 CARD#0123"
-            },
-            {
-               "amount":1.91,
-               "date_posted":"2022-04-26",
-               "date_transacted":"2022-04-26",
-               "currency":"USD",
-               "description":"CMS Vending"
-            },
-            {
-               "amount":8.75,
-               "date_posted":"2022-04-26",
-               "date_transacted":"2022-04-26",
-               "currency":"USD",
-               "description":"MONEY ORDER"
-            },
-            {
-               "amount":13.13,
-               "date_posted":"2022-04-26",
-               "date_transacted":"2022-04-26",
-               "currency":"USD",
-               "description":"DEBIT CARD PURCHASE XXXXX0123 GROUPON INC GROUPON.COM IL"
-            },
-            {
-               "amount":7.29,
-               "date_posted":"2022-04-26",
-               "date_transacted":"2022-04-26",
-               "currency":"USD",
-               "description":"APL* ITUNES.COM One Apple Park Way 012-012-01"
-            },
-            {
-               "amount":0.75,
-               "date_posted":"2022-04-27",
-               "date_transacted":"2022-04-27",
-               "currency":"USD",
-               "description":"CONTACTS SUBSCRIPTIO HTTPSWWW.HUBB NY        "
+        },
+        {
+            "type": "loan",
+            "subtype": "student",
+            "liability": {
+                "type": "student",
+                "origination_date": "2020-01-01",
+                "principal": 10000,
+                "nominal_apr": 6.25,
+                "loan_name": "Plaid Student Loan",
+                "repayment_model": {
+                    "type": "standard",
+                    "non_repayment_months": 12,
+                    "repayment_months": 120
+                }
             }
-         ]
-      },
-      {
-         "type":"loan",
-         "subtype":"student",
-         "liability":{
-            "type":"student",
-            "origination_date":"2020-01-01",
-            "principal":10000,
-            "nominal_apr":6.25,
-            "loan_name":"Plaid Student Loan",
-            "repayment_model":{
-               "type":"standard",
-               "non_repayment_months":12,
-               "repayment_months":120
+        },
+        {
+            "type": "credit",
+            "subtype": "credit card",
+            "starting_balance": 10000,
+            "inflow_model": {
+                "type": "monthly-interest-only-payment",
+                "payment_day_of_month": 15,
+                "statement_day_of_month": 13,
+                "transaction_name": "Interest Payment"
+            },
+            "liability": {
+                "type": "credit",
+                "purchase_apr": 12.9,
+                "balance_transfer_apr": 15.24,
+                "cash_apr": 28.45,
+                "special_apr": 0,
+                "last_payment_amount": 500,
+                "minimum_payment_amount": 10
             }
-         }
-      },
-      {
-         "type":"credit",
-         "subtype":"credit card",
-         "starting_balance":10000,
-         "inflow_model":{
-            "type":"monthly-interest-only-payment",
-            "payment_day_of_month":15,
-            "statement_day_of_month":13,
-            "transaction_name":"Interest Payment"
-         },
-         "liability":{
-            "type":"credit",
-            "purchase_apr":12.9,
-            "balance_transfer_apr":15.24,
-            "cash_apr":28.45,
-            "special_apr":0,
-            "last_payment_amount":500,
-            "minimum_payment_amount":10
-         }
-      }
-   ]
+        }
+    ]
 }

--- a/assets/update_dates.py
+++ b/assets/update_dates.py
@@ -1,0 +1,71 @@
+"""
+A script that updates the JSON data for our sandbox assets user so that their 
+most recent transactions are dated to today's date and work backwards from there.
+
+Currently hard-coded to use the assets_custom_user2.json file, but assuming 
+this works, we can look at making it more general purpose
+"""
+
+import json
+from datetime import datetime
+
+
+# Function to calculate the new date
+def scale_date(old_date_str, base_date, target_date):
+    """
+    Given a date string, a base date, and a target date, scale the date string
+    to a new date that is the same distance from the target date as the base date
+    """
+    old_date = datetime.strptime(old_date_str, "%Y-%m-%d")
+    delta = base_date - old_date
+    new_date = target_date - delta
+    return new_date.strftime("%Y-%m-%d")
+
+
+
+def find_most_recent_date(original_data):
+    """
+    Given the JSON data, find the most recent date from the list of transactions
+    """
+    most_recent_date = datetime.min
+    for account in original_data.get("override_accounts", []):
+        for transaction in account.get("transactions", []):
+            for date_field in ["date_posted", "date_transacted"]:
+                date_str = transaction.get(date_field)
+                if date_str:
+                    date = datetime.strptime(date_str, "%Y-%m-%d")
+                    if date > most_recent_date:
+                        most_recent_date = date
+    return most_recent_date
+
+
+sandbox_user_files = [ "assets_custom_user.json", "assets_custom_user2.json"]
+
+# Iterate through each filename in the array
+for user_file in sandbox_user_files:
+
+  with open(user_file, "r", encoding="utf-8") as file:
+      json_data = json.load(file)
+
+  # Determine the most recent date from the JSON data
+  most_recent_date = find_most_recent_date(json_data)
+  today_date = datetime.now()
+
+  # Iterate over each account and transaction to update the dates
+  for account in json_data.get("override_accounts", []):  # Using .get() to avoid KeyError
+      transactions = account.get("transactions")  # Using .get() to avoid KeyError
+      if transactions:  # Check if transactions is not None or empty
+          for transaction in transactions:
+              if "date_posted" in transaction:
+                  transaction["date_posted"] = scale_date(
+                      transaction["date_posted"], most_recent_date, today_date
+                  )
+              if "date_transacted" in transaction:
+                  transaction["date_transacted"] = scale_date(
+                      transaction["date_transacted"], most_recent_date, today_date
+                  )
+
+
+  # Write the updated JSON data to a file
+  with open(user_file, "w", encoding="utf-8") as file:
+      json.dump(json_data, file, indent=4)


### PR DESCRIPTION
This is a python script that...
1. Looks through our two Asset Sandbox user json files
2. Finds the most recent date in these files
3. Sets that date to today, and then scales all other dates proportionately

And then we have a workflow script that, in theory, runs this script once a day and commits the result.

I'm keeping this limited to assets for now, just so we can limit the damage in case something goes wrong.

