### PR TITLE
Add credit card custom user with transactions and liability data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,40 @@ This repo contains JSON files specifying custom users suitable for testing Plaid
 
 You can add these users to the Sandbox environment via the [Test Users page in the Plaid Dashboard](https://dashboard.plaid.com/developers/sandbox?tab=testUsers). For more details, see [Configuring the custom user account](https://plaid.com/docs/sandbox/user-custom/#configuring-the-custom-user-account) in the Plaid documentation.
 
+## Using these files without the Dashboard
+
+You don't need the Dashboard to use a custom user file -- you can create an Item directly via the API, which is useful for scripting, CI, or handing a file like these to an AI-assisted coding tool to set up test data programmatically. Call [`/sandbox/public_token/create`](https://plaid.com/docs/api/sandbox/#sandboxpublic_tokencreate) with:
+
+- `options.override_username` set to the literal string `user_custom`
+- `options.override_password` set to the **entire contents of the custom user file, JSON-stringified into a single string** (not passed as a nested JSON object)
+
+For example, in Python:
+
+```python
+import json
+import requests
+
+with open("liabilities/credit_card_custom_user.json") as f:
+    custom_user_config = json.load(f)
+
+resp = requests.post(
+    "https://sandbox.plaid.com/sandbox/public_token/create",
+    json={
+        "client_id": PLAID_CLIENT_ID,
+        "secret": PLAID_SECRET,
+        "institution_id": "ins_109508",
+        "initial_products": ["liabilities"],
+        "options": {
+            "override_username": "user_custom",
+            "override_password": json.dumps(custom_user_config),
+        },
+    },
+)
+public_token = resp.json()["public_token"]
+```
+
+Then exchange the returned `public_token` via [`/item/public_token/exchange`](https://plaid.com/docs/api/items/#itempublic_tokenexchange) for an `access_token` as usual. Use a non-OAuth institution, such as `ins_109508` (First Platypus Bank) -- see the warning below.
+
 The dates in these test files are automatically updated daily such that the most recent date will be set to today, and then all other dates are adjusted proportionately. After loading these files into Sandbox, you may need to occasionally update them so that Income transactions and data are within the past 90 days, and transactions for other products are within the last 2 years. You can do this by re-fetching these files from Github, or running the `update_dates.py` script.
 
 If you want to customize these files further, see the [Custom User configuration object schema](https://plaid.com/docs/sandbox/user-custom/#configuration-object-schema) for detailed documentation on available options and fields.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,12 @@ This repo contains JSON files specifying custom users suitable for testing Plaid
 
 You can add these users to the Sandbox environment via the [Test Users page in the Plaid Dashboard](https://dashboard.plaid.com/developers/sandbox?tab=testUsers). For more details, see [Configuring the custom user account](https://plaid.com/docs/sandbox/user-custom/#configuring-the-custom-user-account) in the Plaid documentation.
 
-## Using these files without the Dashboard
-
-You don't need the Dashboard to use a custom user file -- you can create an Item directly via the API, which is useful for scripting, CI, or handing a file like these to an AI-assisted coding tool to set up test data programmatically. Call [`/sandbox/public_token/create`](https://plaid.com/docs/api/sandbox/#sandboxpublic_tokencreate) with:
+To use these test users without the Dashboard, directly via the API, call [`/sandbox/public_token/create`](https://plaid.com/docs/api/sandbox/#sandboxpublic_tokencreate) with:
 
 - `options.override_username` set to the literal string `user_custom`
-- `options.override_password` set to the **entire contents of the custom user file, JSON-stringified into a single string** (not passed as a nested JSON object)
+- `options.override_password` set to the entire contents of the custom user file, JSON-stringified into a single string
 
-For example, in Python:
+For example:
 
 ```python
 import json
@@ -40,8 +38,6 @@ resp = requests.post(
 )
 public_token = resp.json()["public_token"]
 ```
-
-Then exchange the returned `public_token` via [`/item/public_token/exchange`](https://plaid.com/docs/api/items/#itempublic_tokenexchange) for an `access_token` as usual. Use a non-OAuth institution, such as `ins_109508` (First Platypus Bank) -- see the warning below.
 
 The dates in these test files are automatically updated daily such that the most recent date will be set to today, and then all other dates are adjusted proportionately. After loading these files into Sandbox, you may need to occasionally update them so that Income transactions and data are within the past 90 days, and transactions for other products are within the last 2 years. You can do this by re-fetching these files from Github, or running the `update_dates.py` script.
 

--- a/liabilities/credit_card_custom_user.json
+++ b/liabilities/credit_card_custom_user.json
@@ -1,0 +1,62 @@
+{
+  "override_accounts": [
+    {
+      "type": "credit",
+      "subtype": "credit card",
+      "starting_balance": 1245.67,
+      "force_available_balance": 8754.33,
+      "meta": {
+        "name": "Plaid Credit Card",
+        "official_name": "Plaid Platinum Rewards Card",
+        "limit": 10000
+      },
+      "transactions": [
+        {
+          "date_transacted": "2026-07-20",
+          "date_posted": "2026-07-21",
+          "amount": 87.43,
+          "description": "Amazon.com Purchase",
+          "currency": "USD"
+        },
+        {
+          "date_transacted": "2026-07-18",
+          "date_posted": "2026-07-19",
+          "amount": 156.89,
+          "description": "Whole Foods Market",
+          "currency": "USD"
+        },
+        {
+          "date_transacted": "2026-07-16",
+          "date_posted": "2026-07-17",
+          "amount": 45,
+          "description": "Shell Gas Station",
+          "currency": "USD"
+        },
+        {
+          "date_transacted": "2026-07-14",
+          "date_posted": "2026-07-15",
+          "amount": 1200,
+          "description": "Monthly Rent Payment",
+          "currency": "USD"
+        },
+        {
+          "date_transacted": "2026-07-12",
+          "date_posted": "2026-07-13",
+          "amount": 23.5,
+          "description": "Starbucks Coffee",
+          "currency": "USD"
+        }
+      ],
+      "liability": {
+        "type": "credit",
+        "purchase_apr": 16.99,
+        "cash_apr": 24.99,
+        "balance_transfer_apr": 18.99,
+        "special_apr": 0,
+        "last_payment_amount": 250,
+        "minimum_payment_amount": 35,
+        "is_overdue": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a credit card custom Sandbox user under `liabilities/` with both transaction history and full liability data, addressing the original request in #34.

This combination previously returned null liabilities data due to a short-circuit bug in Sandbox's liabilities population, which has since been fixed — this example verifies the fix and gives requesters a ready-made file to load.

Also documents the API-only path for loading these files (`user_custom` + `override_password` on `/sandbox/public_token/create`), which Plaid's docs describe as two separate mechanisms rather than one combined recipe. Useful for scripting or handing a file to an AI coding tool instead of using the Dashboard.

Closes #34